### PR TITLE
Implemented RDB checksum protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,5 @@ To restore data, it takes all RESP strings from the file, parses them, and rerun
 `BGSAVE` uses `COW (Copy-On-Write)` in the actual Redis implementation. This uses an OS-provided memory optimization algorithm.
 This isn't quite possible in Go, because Go is garbage collected.
 So true background saving is not supported.
+
+Saving RDB files has SHA256 checksum protection to ensure data is saved correctly.


### PR DESCRIPTION
- Saving to RDB now has SHA-256 checksum protection. The hash of the data before and after writing to file is checked to ensure data integrity.

Closes #24 