### PR TITLE
Implemented EXPIRE and TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Overview of RESP:
 - **Get how many keys are the in DB**: Use `DBSIZE` with no arguments to get how many keys are stored in the DB.
 - **Delete the whole DB**: To purge the whole DB, use `FLUSHDB` with no arguments.
 - **Authenticate**: All commands except `COMMAND` and `AUTH` require authentication to use. Use `AUTH <PASS>` to log in. By default, the password is `hey`, but this can be changed in the `redis.conf` file. (See [Notes](#notes) for more).
+- **Set an expiry for a key**: Use `EXPIRE <KEY> <SECONDS>` to set an expiry for a key. Once the expiry has passed, delete the key automatically. (See [Notes](#notes) for more).
+- **Check how long a key has left to live**: Use `TTL <KEY>`. Returns `-2` if no such key is found, `-1` is no expiry is found on the key, or any other number for the number of seconds left to live.
 - **End a message**: All RESP messages end with `\r\n`.
 
 ## Examples
@@ -99,10 +101,13 @@ To restore data, it takes all RESP strings from the file, parses them, and rerun
 ## Notes
 
 `BGSAVE` uses `COW (Copy-On-Write)` in the actual Redis implementation. This uses an OS-provided memory optimization algorithm.
-This isn't quite possible in Go, because Go is garbage collected.
-So true background saving is not supported.
+This isn't quite possible in Go, because Go is garbage collected. So true background saving is not supported.
 
 Saving RDB files has SHA256 checksum protection to ensure data is saved correctly.
 
 Real Redis has a much more complicated way of authenticating users called ACL (Access Control List).
 The implemented approach is much simpler. ACL involves a username and password, but this implementation only supports a password.
+
+Real Redis handles expiry in 2 ways: using `GET`,and other commands to see if a key is expired,
+or by using a background process to periodically check a sample of keys for expiry.
+This second method is not implemented here, and may never be.

--- a/db.go
+++ b/db.go
@@ -1,20 +1,39 @@
 package main
 
-import "sync"
+import (
+	"sync"
+	"time"
+)
 
 // A Database type containing a key, value store and
 // a mutex lock to allow concurrency
 type Database struct {
-	store map[string]string
+	store map[string]*Key
 	mu    sync.RWMutex
 }
 
 // NewDatabase creates a new Database type
 func NewDatabase() *Database {
 	return &Database{
-		store: map[string]string{},
+		store: map[string]*Key{},
 		mu:    sync.RWMutex{},
 	}
 }
 
+// Set is a "public" method to set values to DB keys, which we prefer to act "private"
+func (db *Database) Set(k string, v string) {
+	db.store[k] = &Key{V: v}
+}
+
+// Delete is a "public" method to remove a key from the database
+func (db *Database) Delete(k string) {
+	delete(db.store, k)
+}
+
 var DB = NewDatabase()
+
+// Creating a key allows us to store expiry time
+type Key struct {
+	V   string
+	Exp time.Time
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,9 @@ import (
 	"time"
 )
 
+// The number of seconds since Jan 1 1970
+var UNIX_TIMESTAMP int64 = time.Time{}.Unix()
+
 func main() {
 	// Read config file
 	log.Println("Reading config file")
@@ -90,7 +93,7 @@ type AppState struct {
 	conf          *Config
 	aof           *AOF
 	bgSaveRunning bool
-	dbCopy        map[string]string
+	dbCopy        map[string]*Key
 }
 
 // NewAppState creates a new AppState type with the given Config settings


### PR DESCRIPTION
- Implemented the closely-related EXPIRE and TTL commands.
- EXPIRE sets a number of seconds from now a key should expire (and be deleted from DB)
- TTL checks how long a key has to live
- Updated README

Closes #29 
Closes #28 