### PR TITLE
Implemented memory tracking

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -12,3 +12,7 @@ dbfilename backup.rdb
 
 #AUTH
 requirepass hey
+
+# MEMORY
+maxmemory 256
+maxmemory-policy noeviction


### PR DESCRIPTION
- Implemented `maxmemory` and `maxmemory-policy` config items supporting memory tracking
- Implemented the `noeviction` eviction policy
- Track the approximate amount of memory used by the DB when setting or deleting from the db

This is mostly just support infrastructure for later eviction policy development.

Closes #35  